### PR TITLE
Boolean AND as standard search operator

### DIFF
--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -1,5 +1,6 @@
 package controllers.nwbib;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +14,6 @@ import play.libs.WS.WSRequestHolder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import com.typesafe.config.ConfigObject;
 
 /**
  * Access Lobid title data.
@@ -43,7 +43,12 @@ public class Lobid {
 				.setQueryParameter("size", size + "")
 				.setQueryParameter("sort", sort);
 		if(!q.trim().isEmpty())
-			requestHolder = requestHolder.setQueryParameter("q", q);
+			requestHolder = requestHolder.setQueryParameter("q",
+					// if query string syntax is used, leave it alone:
+					q.matches(".*?([+\\-~]|AND|OR).*?") ? q :
+					// else prepend '+' to all terms for AND search:
+					Arrays.asList(q.split(" ")).stream().map(x -> "+" + x)
+							.collect(Collectors.joining(" ")));
 		if(!author.trim().isEmpty())
 			requestHolder = requestHolder.setQueryParameter("author", author);
 		if(!name.trim().isEmpty())


### PR DESCRIPTION
See https://wiki1.hbz-nrw.de/display/SEM/NWBib-Treffen+10.9.2014
- Implicitly use boolean AND for plain queries over all fields (this pull request)
- Use tweaked API with Operator.AND for specific field queries (see https://github.com/hbz/lobid/pull/58)

@acka47 assigning to you, we don't have an issue for this. If you +1 I will merge and deploy to production.

Deployed to staging:

http://test.lobid.org/nwbib/search?query=glessen+mühlen (all fields)
http://test.lobid.org/nwbib/search?name=paderborn+fußball (title)
http://test.lobid.org/nwbib/search?publisher=gruner+jahr (publisher)
