### PR TITLE
Get all values on item facet request

### DIFF
--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -328,7 +328,9 @@ public class Lobid {
 						.setQueryParameter("id", id)//
 						.setQueryParameter("field", field)//
 						.setQueryParameter("from", "0")
-						.setQueryParameter("size", Application.MAX_FACETS + "")
+						.setQueryParameter("size",
+								field.equals(Application.ITEM_FIELD) ? "9999"
+										: Application.MAX_FACETS + "")
 						.setQueryParameter("corporation", corporation);
 		if (!q.isEmpty())
 			request = request.setQueryParameter("word", preprocess(q));


### PR DESCRIPTION
Since we don't actually display the items in a facet, but their owners, we can't use the most frequent values only, since these are the most frequent items, not the most frequent owners.

Will resolve #279.