### PR TITLE
Remove nwbibspatial notations 96 and 97 if coverage exists

### DIFF
--- a/app/views/TableRow.java
+++ b/app/views/TableRow.java
@@ -34,6 +34,18 @@ public enum TableRow {
 			List<String> vs = values;
 			if (doc.has("coverage")) { // see https://github.com/hbz/nwbib/issues/276
 				List<String> remove = Arrays.asList(//
+						"http://purl.org/lobid/nwbib-spatial#n10",
+						"http://purl.org/lobid/nwbib-spatial#n12",
+						"http://purl.org/lobid/nwbib-spatial#n14",
+						"http://purl.org/lobid/nwbib-spatial#n24",
+						"http://purl.org/lobid/nwbib-spatial#n28",
+						"http://purl.org/lobid/nwbib-spatial#n35",
+						"http://purl.org/lobid/nwbib-spatial#n36",
+						"http://purl.org/lobid/nwbib-spatial#n37",
+						"http://purl.org/lobid/nwbib-spatial#n52",
+						"http://purl.org/lobid/nwbib-spatial#n54",
+						"http://purl.org/lobid/nwbib-spatial#n72",
+						"http://purl.org/lobid/nwbib-spatial#n74",
 						"http://purl.org/lobid/nwbib-spatial#n96",
 						"http://purl.org/lobid/nwbib-spatial#n97");
 				vs = vs.stream().filter(v -> !remove.contains(v))

--- a/app/views/TableRow.java
+++ b/app/views/TableRow.java
@@ -31,10 +31,17 @@ public enum TableRow {
 		@Override
 		public String process(JsonNode doc, String property, String param,
 				String label, List<String> values, Optional<List<String>> keys) {
-			return values.isEmpty() ? ""
+			List<String> vs = values;
+			if (doc.has("coverage")) { // see https://github.com/hbz/nwbib/issues/276
+				List<String> remove = Arrays.asList(//
+						"http://purl.org/lobid/nwbib-spatial#n96",
+						"http://purl.org/lobid/nwbib-spatial#n97");
+				vs = vs.stream().filter(v -> !remove.contains(v))
+						.collect(Collectors.toList());
+			}
+			return vs.isEmpty() ? ""
 					: String.format("<tr><td>%s</td><td>%s</td></tr>", label,
-							values.stream()
-									.filter(value -> !value.contains("http://dewey.info"))
+							vs.stream().filter(value -> !value.contains("http://dewey.info"))
 									.map(val -> label(doc, property, param, val, keys))
 									.collect(Collectors.joining(
 											property.equals("subjectChain") ? " <br/> " : " | ")));

--- a/app/views/tags/result_doc.scala.html
+++ b/app/views/tags/result_doc.scala.html
@@ -131,8 +131,8 @@
    @subordinated("@graph.http://purl.org/lobid/lv#containedIn.@id", id, "Enthält", ("Beitrag", "Beiträge"))
   }
 
-  @result_field(if(!(doc \\ "coverage").isEmpty && !(doc \\ "nwbibspatial").isEmpty){"Raumsystematik: Orte"}else{"Raumsystematik"}, "coverage", doc, TableRow.VALUES, valueLabel = Option(Seq()), param="raw")
-  @result_field(if(!(doc \\ "coverage").isEmpty && !(doc \\ "nwbibspatial").isEmpty){"Raumsystematik: Regionen"}else{"Raumsystematik"}, "nwbibspatial", doc, TableRow.VALUES, valueLabel = Option(Seq()), param="nwbibspatial")
+  @result_field("Raumsystematik", "coverage", doc, TableRow.VALUES, valueLabel = Option(Seq()), param="raw")
+  @result_field("Raumsystematik", "nwbibspatial", doc, TableRow.VALUES, valueLabel = Option(Seq()), param="nwbibspatial")
   @result_field("Sachsystematik", "nwbibsubject", doc, TableRow.VALUES, valueLabel = Option(Seq()), param="nwbibsubject")
   @result_field("Schlagwörter", "subject", doc, TableRow.VALUES, valueLabel = gndEntities, param="subject")
   @result_field("Schlagwortfolge", "subjectChain", doc, TableRow.VALUES, valueLabel = Option(Seq()))


### PR DESCRIPTION
Also removes custom labels if both `coverage` and `nwbibspatial` are shown to avoid excessive complexity due to added filtering.

Will resolve #276 
