### PR TITLE
Cache item owners for items map

### DIFF
--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -62,20 +62,19 @@ public class Lobid {
 	}
 
 	/**
-	 * @param id The organisation ID
-	 * @return The organisation JSON content
+	 * @param url The URL to call
+	 * @return A JSON response from the URL, or an empty JSON object
 	 */
-	public static JsonNode getOrganisation(String id) {
-		String cacheKey = String.format("organisation.json.%s", id);
-		JsonNode cachedOrganisation = (JsonNode) Cache.get(cacheKey);
-		if (cachedOrganisation != null) {
-			return cachedOrganisation;
+	public static JsonNode cachedJsonCall(String url) {
+		String cacheKey = String.format("json.%s", url);
+		JsonNode org = (JsonNode) Cache.get(cacheKey);
+		if (org != null) {
+			return org;
 		}
-		Logger.debug("Item owner not cached, GET: {}", id);
+		Logger.debug("Not cached, GET: {}", url);
 		Promise<JsonNode> promise =
-				WS.url(Application.CONFIG.getString("orgs.api") + "/" + id).get()
-						.map(response -> response.getStatus() == Http.Status.OK
-								? response.asJson() : Json.newObject());
+				WS.url(url).get().map(response -> response.getStatus() == Http.Status.OK
+						? response.asJson() : Json.newObject());
 		promise.onRedeem(json -> {
 			Cache.set(cacheKey, json, Application.ONE_DAY);
 		});

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -53,9 +53,7 @@ public class Lobid {
 		if (DATA_2) {
 			String url = String.format(
 					Application.CONFIG.getString("feature.lobid2.indexUrlFormat"), id);
-			Promise<JsonNode> jsonResponse =
-					WS.url(url).get().map(response -> response.asJson());
-			return jsonResponse.get(10000);
+			return cachedJsonCall(url);
 		}
 		throw new IllegalStateException(
 				"Only implemented for Lobid.DATA_2 feature");
@@ -67,16 +65,16 @@ public class Lobid {
 	 */
 	public static JsonNode cachedJsonCall(String url) {
 		String cacheKey = String.format("json.%s", url);
-		JsonNode org = (JsonNode) Cache.get(cacheKey);
-		if (org != null) {
-			return org;
+		JsonNode json = (JsonNode) Cache.get(cacheKey);
+		if (json != null) {
+			return json;
 		}
 		Logger.debug("Not cached, GET: {}", url);
 		Promise<JsonNode> promise =
 				WS.url(url).get().map(response -> response.getStatus() == Http.Status.OK
 						? response.asJson() : Json.newObject());
-		promise.onRedeem(json -> {
-			Cache.set(cacheKey, json, Application.ONE_DAY);
+		promise.onRedeem(jsonResponse -> {
+			Cache.set(cacheKey, jsonResponse, Application.ONE_DAY);
 		});
 		return promise.get(10000);
 	}

--- a/app/views/tags/items_map.scala.html
+++ b/app/views/tags/items_map.scala.html
@@ -62,13 +62,7 @@
 @markers(items: Map[String,List[String]]) = {
     @for((key,i) <- items.keySet.toList.sortWith((k1:String,k2:String)=>controllers.nwbib.Lobid.compareIsil(k1,k2)).zipWithIndex;
         owner = Application.CONFIG.getString("orgs.api")+"/"+key;
-        response = Cache.getOrElse[play.api.libs.ws.WSResponse](owner) {
-          play.Logger.debug("Item owner not cached, GET: {}", owner)
-          val r = Await.result(WS.url(owner).get(), 5.seconds)
-          if(r.status == play.mvc.Http.Status.OK) Cache.set(owner, r, 7.days)
-          r
-        };
-        json = if(response.status == play.mvc.Http.Status.OK) response.json else Json.obj();
+        json = Json.parse(controllers.nwbib.Lobid.getOrganisation(key).toString);
         ownerUrl = if((json\\"url").isEmpty) owner else (json\\"url")(0).as[String];
         ownerName = if((json\\"name").isEmpty) "" else (json\\"name")(0).as[String]) {
 

--- a/app/views/tags/items_map.scala.html
+++ b/app/views/tags/items_map.scala.html
@@ -10,7 +10,7 @@
 @import ExecutionContext.Implicits.global
 @import scala.concurrent.duration._
 @import play.api.Play.current
-@import controllers.nwbib.Application
+@import controllers.nwbib._
 @import play.api.cache.Cache
 
 @string(value: JsValue) = { @value.asOpt[String].getOrElse("--") }
@@ -60,15 +60,15 @@
     </script>
 
 @markers(items: Map[String,List[String]]) = {
-    @for((key,i) <- items.keySet.toList.sortWith((k1:String,k2:String)=>controllers.nwbib.Lobid.compareIsil(k1,k2)).zipWithIndex;
+    @for((key,i) <- items.keySet.toList.sortWith((k1:String,k2:String)=>Lobid.compareIsil(k1,k2)).zipWithIndex;
         owner = Application.CONFIG.getString("orgs.api")+"/"+key;
-        json = Json.parse(controllers.nwbib.Lobid.getOrganisation(key).toString);
+        json = Json.parse(Lobid.cachedJsonCall(owner).toString);
         ownerUrl = if((json\\"url").isEmpty) owner else (json\\"url")(0).as[String];
         ownerName = if((json\\"name").isEmpty) "" else (json\\"name")(0).as[String]) {
 
           var details = '<tr><td><i>Bibliothek:</i></td><td>'+
             '<i>@if(!ownerName.isEmpty){<a href="@ownerUrl">@ownerName</a>}else{&lt;Keine Angabe&gt;}</i></td></tr>'
-            @defining(controllers.nwbib.Lobid.opacUrl(items(key).head)){ opacLink =>
+            @defining(Lobid.opacUrl(items(key).head)){ opacLink =>
               @if(opacLink!=null){+'<tr><td>Verfügbarkeit:</td>'+'<td><a href="@opacLink">Lokalen Katalog abfragen</a></td></tr>'};
             }
           tableDetails@(hitId) = details;
@@ -77,9 +77,7 @@
           else
             allTableDetails@(hitId) += '<tr><th style="width: 30%"/><th style="width: 70%"/></tr>' + tableDetails@(hitId);
         @for((item,i) <- items(key).zipWithIndex;
-            requestUri = item+"?format=full";
-            jsonFuture = WS.url(requestUri).get().map(x=>x.json);
-            itemJson = Await.result(jsonFuture, 5.second);
+            itemJson = Json.parse(Lobid.cachedJsonCall(item+"?format=full").toString);
             owners = (itemJson\\"owner");
             if(!owners.isEmpty);
             signatures = (itemJson\\"callNumber");

--- a/app/views/tags/items_map.scala.html
+++ b/app/views/tags/items_map.scala.html
@@ -11,6 +11,7 @@
 @import scala.concurrent.duration._
 @import play.api.Play.current
 @import controllers.nwbib.Application
+@import play.api.cache.Cache
 
 @string(value: JsValue) = { @value.asOpt[String].getOrElse("--") }
 
@@ -61,7 +62,12 @@
 @markers(items: Map[String,List[String]]) = {
     @for((key,i) <- items.keySet.toList.sortWith((k1:String,k2:String)=>controllers.nwbib.Lobid.compareIsil(k1,k2)).zipWithIndex;
         owner = Application.CONFIG.getString("orgs.api")+"/"+key;
-        response = Await.result(WS.url(owner).get(), 5.second);
+        response = Cache.getOrElse[play.api.libs.ws.WSResponse](owner) {
+          play.Logger.debug("Item owner not cached, GET: {}", owner)
+          val r = Await.result(WS.url(owner).get(), 5.seconds)
+          if(r.status == play.mvc.Http.Status.OK) Cache.set(owner, r, 7.days)
+          r
+        };
         json = if(response.status == play.mvc.Http.Status.OK) response.json else Json.obj();
         ownerUrl = if((json\\"url").isEmpty) owner else (json\\"url")(0).as[String];
         ownerName = if((json\\"name").isEmpty) "" else (json\\"name")(0).as[String]) {


### PR DESCRIPTION
Owners are cached globally, i.e. every owner will only be loaded once, not once for every resource.

Will resolve #251