### PR TITLE
Extract inline API URLs and catch missing label

### DIFF
--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -684,7 +684,8 @@ public class Application extends Controller {
 				.distinct().collect(Collectors.toList());
 		return count(itemUrisWithoutSignatures).entrySet().stream()
 				.map(entry -> Json.toJson(ImmutableMap.of(//
-						"term", "http://lobid.org/organisation/" + entry.getKey(), //
+						"term",
+						Application.CONFIG.getString("orgs.api") + "/" + entry.getKey(), //
 						"count", entry.getValue())));
 	}
 

--- a/app/views/tags/items_map.scala.html
+++ b/app/views/tags/items_map.scala.html
@@ -77,7 +77,7 @@ map.addLayer(layer);
           else
             allTableDetails += '<tr><th style="width: 30%"/><th style="width: 70%"/></tr>' + tableDetails;
         @for((item,i) <- items(key).zipWithIndex;
-            itemJson = Json.parse(Lobid.cachedJsonCall(item+"?format=full").toString);
+            itemJson = Json.parse(Lobid.cachedJsonCall(item.replaceAll("https?://lobid\\.org/item", Application.CONFIG.getString("item.api"))+"?format=full").toString);
             owners = (itemJson\\"owner");
             if(!owners.isEmpty);
             signatures = (itemJson\\"callNumber");

--- a/conf/nwbib.conf
+++ b/conf/nwbib.conf
@@ -1,4 +1,5 @@
 nwbib.api="http://lobid.org/resource"
+item.api="http://lobid.org/item"
 hbz01.api="http://beta.lobid.org/hbz01"
 orgs.api="http://beta.lobid.org/organisations"
 nwbib.set="http://lobid.org/resource/NWBib"


### PR DESCRIPTION
We're having DNS issues on our servers, which caused an outage of lobid and NWBib today.

This change extracts inline API calls to the config file, which allowed me to restore services by configuring all internal API calls via IP numbers.

Already deployed to production.