### PR TITLE
Move NWBib classifications into embedded Elasticsearch index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist
 /.target
 /.cache
 /bin
+.settings/org.scala-ide.sdt.core.prefs
+/data

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
   - wget http://downloads.typesafe.com/typesafe-activator/${ACTIVATOR_VERSION}/typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
   - unzip typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
 script:
-  - ./activator-${ACTIVATOR_VERSION}-minimal/activator "test-only tests.ApplicationTest"
+  - ./activator-${ACTIVATOR_VERSION}-minimal/activator test

--- a/app/Global.java
+++ b/app/Global.java
@@ -1,0 +1,25 @@
+import controllers.nwbib.Classification;
+import play.Application;
+import play.GlobalSettings;
+
+/**
+ * Application global settings. Start and stop Classification index.
+ * 
+ * See https://www.playframework.com/documentation/2.3.x/JavaGlobal
+ * 
+ * @author Fabian Steeg (fsteeg)
+ */
+public class Global extends GlobalSettings {
+
+	@Override
+	public void onStart(Application app) {
+		super.onStart(app);
+		Classification.indexStartup();
+	}
+
+	@Override
+	public void onStop(Application app) {
+		Classification.indexShutdown();
+		super.onStop(app);
+	}
+}

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -105,10 +105,6 @@ public class Application extends Controller {
 
 	static Form<String> queryForm = Form.form(String.class);
 
-	/** Access to the NWBib classification data stored in ES. */
-	public final static Classification CLASSIFICATION = new Classification(
-			CONFIG.getString("nwbib.cluster"), CONFIG.getString("nwbib.server"));
-
 	static final int ONE_HOUR = 60 * 60;
 	/** The number of seconds in one day. */
 	public static final int ONE_DAY = 24 * ONE_HOUR;
@@ -290,7 +286,7 @@ public class Application extends Controller {
 			return cachedResult;
 		Logger.debug("Not cached: {}, will cache for one day", cacheId);
 		Promise<JsonNode> jsonPromise =
-				Promise.promise(() -> CLASSIFICATION.ids(q, t));
+				Promise.promise(() -> Classification.ids(q, t));
 		Promise<Result> result;
 		if (!callback.isEmpty())
 			result = jsonPromise.map((JsonNode json) -> ok(
@@ -313,13 +309,13 @@ public class Application extends Controller {
 		if (t.isEmpty()) {
 			result = ok(register.render());
 		} else {
-			SearchResponse response = CLASSIFICATION.dataFor(t);
+			SearchResponse response = Classification.dataFor(t);
 			if (response == null) {
 				Logger.error("Failed to get data for register type: " + t);
 				flashError();
 				return internalServerError(browse_register.render(null, t));
 			}
-			JsonNode sorted = CLASSIFICATION.sorted(response);
+			JsonNode sorted = Classification.sorted(response);
 			result = ok(browse_register.render(sorted.toString(), t));
 		}
 		Cache.set("result." + t, result, ONE_DAY);
@@ -338,7 +334,7 @@ public class Application extends Controller {
 		if (t.isEmpty()) {
 			result = ok(classification.render());
 		} else {
-			SearchResponse response = CLASSIFICATION.dataFor(t);
+			SearchResponse response = Classification.dataFor(t);
 			if (response == null) {
 				Logger.error("Failed to get data for classification type: " + t);
 				flashError();
@@ -354,7 +350,7 @@ public class Application extends Controller {
 			String t) {
 		List<JsonNode> topClasses = new ArrayList<>();
 		Map<String, List<JsonNode>> subClasses = new HashMap<>();
-		CLASSIFICATION.buildHierarchy(response, topClasses, subClasses);
+		Classification.buildHierarchy(response, topClasses, subClasses);
 		String topClassesJson = Json.toJson(topClasses).toString();
 		return ok(browse_classification.render(topClassesJson, subClasses, t));
 	}

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -317,7 +317,7 @@ public class Lobid {
 		String type =
 				uri.contains("spatial") ? Classification.Type.SPATIAL.elasticsearchType
 						: Classification.Type.NWBIB.elasticsearchType;
-		String label = Application.CLASSIFICATION.label(uri, type);
+		String label = Classification.label(uri, type);
 		label = HtmlEscapers.htmlEscaper().escape(label);
 		label = label.trim().isEmpty() ? uri : label;
 		Cache.set(cacheKey, label);

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,11 @@ libraryDependencies ++= Seq(
   cache,
   javaWs,
   "com.typesafe.play" % "play-test_2.11" % "2.3.10",
-  "org.elasticsearch" % "elasticsearch" % "1.3.2" withSources(),
-  "org.mockito" % "mockito-core" % "1.9.5"
+  "org.elasticsearch" % "elasticsearch" % "1.7.5" withSources(),
+  "org.mockito" % "mockito-core" % "1.9.5",
+  "com.github.jsonld-java" % "jsonld-java" % "0.3",
+  "com.github.jsonld-java" % "jsonld-java-jena" % "0.3",
+  "org.apache.jena" % "jena-arq" % "2.9.3"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)

--- a/conf/nwbib.conf
+++ b/conf/nwbib.conf
@@ -2,13 +2,19 @@ nwbib.api="http://lobid.org/resource"
 hbz01.api="http://beta.lobid.org/hbz01"
 orgs.api="http://beta.lobid.org/organisations"
 nwbib.set="http://lobid.org/resource/NWBib"
-nwbib.server="193.30.112.171"
-nwbib.cluster="quaoar"
 
 # Feature toggle: use lobid 2.0 data for presentation
 feature.lobid2 {
 	enabled=true
 	indexUrlFormat="http://lobid.org/resources/%s"
+}
+
+# Embedded Elasticsearch index for classification data
+index {
+	es.port.http=8010
+	es.port.tcp=8110
+	data.nwbibsubject="https://raw.githubusercontent.com/lobid/vocabs/master/nwbib/nwbib.ttl"
+	data.nwbibspatial="https://raw.githubusercontent.com/lobid/vocabs/master/nwbib/nwbib-spatial.ttl"
 }
 
 type.labels={

--- a/test/tests/ApplicationTest.java
+++ b/test/tests/ApplicationTest.java
@@ -2,9 +2,14 @@
 
 package tests;
 
+import static controllers.nwbib.Application.CONFIG;
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -32,9 +37,8 @@ public class ApplicationTest {
 
 	@Test
 	public void classificationLabelNotAvailable() {
-		assertThat(new Classification("no-cluster", "no-server")
-				.label("http://purl.org/lobid/nwbib-spatial#n58", "no-type"))
-						.as("empty label").isEqualTo("");
+		assertThat(Classification.label("http://purl.org/lobid/nwbib-spatial#n58",
+				"no-type")).as("empty label").isEqualTo("");
 	}
 
 	@Test
@@ -67,6 +71,28 @@ public class ApplicationTest {
 								"http://purl.org/dc/terms/BibliographicResource"),
 				"type.labels");
 		assertThat(selected).isEqualTo("http://purl.org/lobid/lv#EditedVolume");
+	}
+
+	@Test
+	public void classificationNwbibsubject()
+			throws MalformedURLException, IOException {
+		List<String> nwbibsubjects = Classification
+				.toJsonLd(new URL(CONFIG.getString("index.data.nwbibsubject")));
+		nwbibsubjects.forEach(System.out::println);
+		assertThat(nwbibsubjects.size()).isEqualTo(998);
+		assertThat(nwbibsubjects.toString()).contains("Allgemeine Landeskunde")
+				.contains("Landesbeschreibungen").contains("Reiseberichte");
+	}
+
+	@Test
+	public void classificationNwbibspatial()
+			throws MalformedURLException, IOException {
+		List<String> nwbibspatials = Classification
+				.toJsonLd(new URL(CONFIG.getString("index.data.nwbibspatial")));
+		nwbibspatials.forEach(System.out::println);
+		assertThat(nwbibspatials.size()).isEqualTo(45);
+		assertThat(nwbibspatials.toString()).contains("Nordrhein-Westfalen")
+				.contains("Rheinland").contains("Grafschaft, Herzogtum Jülich");
 	}
 
 }

--- a/test/tests/InputStringsTest.java
+++ b/test/tests/InputStringsTest.java
@@ -29,7 +29,6 @@ import play.mvc.Result;
 import play.test.FakeRequest;
 import play.test.Helpers;
 
-/* Uses actual data, not available in CI. Run locally with `play test`. */
 /**
  * Test nasty input strings using data from
  * https://github.com/minimaxir/big-list-of-naughty-strings

--- a/test/tests/IntegrationTest.java
+++ b/test/tests/IntegrationTest.java
@@ -5,9 +5,6 @@ package tests;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static play.test.Helpers.HTMLUNIT;
-import static play.test.Helpers.fakeApplication;
-import static play.test.Helpers.inMemoryDatabase;
 import static play.test.Helpers.running;
 import static play.test.Helpers.testServer;
 
@@ -25,11 +22,9 @@ import controllers.nwbib.Lobid;
 import play.libs.F.Promise;
 import play.mvc.Http;
 import play.test.Helpers;
-import play.test.TestBrowser;
 import play.twirl.api.Content;
 import views.ReverseGeoLookup;
 
-/* Uses actual data, not available in CI. Run locally with `play test`. */
 /**
  * See http://www.playframework.com/documentation/2.3.x/JavaFunctionalTest
  */
@@ -48,58 +43,37 @@ public class IntegrationTest {
 	}
 
 	@Test
-	public void testSpatialClassification() {
-		running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT,
-				(TestBrowser browser) -> {
-					browser.goTo("http://localhost:3333/classification?t=Raumsystematik");
-					assertThat(browser.pageSource()).contains("Nordrhein-Westfalen")
-							.contains("Rheinland").contains("Grafschaft, Herzogtum Jülich");
-				});
-	}
-
-	@Test
-	public void testClassification() {
-		running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT,
-				(TestBrowser browser) -> {
-					browser.goTo("http://localhost:3333/classification?t=Sachsystematik");
-					assertThat(browser.pageSource()).contains("Allgemeine Landeskunde")
-							.contains("Landesbeschreibungen").contains("Reiseberichte");
-				});
-	}
-
-	@Test
 	public void testFacets() {
-		running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT,
-				(TestBrowser browser) -> {
-					String field = Application.TYPE_FIELD;
-					Promise<JsonNode> jsonPromise = Lobid.getFacets("köln", "", "", "",
-							"", "", "", "", "", "", "", field, "", "", "", "", "", "");
-					JsonNode facets = jsonPromise.get(Lobid.API_TIMEOUT);
-					assertThat(facets.findValues("term").stream().map(e -> e.asText())
-							.collect(Collectors.toList())).contains(
-									"http://purl.org/dc/terms/BibliographicResource",
-									"http://purl.org/ontology/bibo/Article",
-									"http://purl.org/ontology/bibo/Book",
-									"http://purl.org/ontology/bibo/Journal",
-									"http://purl.org/ontology/bibo/MultiVolumeBook",
-									"http://purl.org/ontology/bibo/Thesis",
-									"http://purl.org/lobid/lv#Miscellaneous",
-									"http://purl.org/ontology/bibo/Proceedings",
-									"http://purl.org/lobid/lv#EditedVolume",
-									"http://purl.org/lobid/lv#Biography",
-									"http://purl.org/lobid/lv#Festschrift",
-									"http://purl.org/ontology/bibo/Newspaper",
-									"http://purl.org/lobid/lv#Bibliography",
-									"http://purl.org/ontology/bibo/Series",
-									"http://purl.org/lobid/lv#OfficialPublication",
-									"http://purl.org/ontology/bibo/ReferenceSource",
-									"http://purl.org/ontology/mo/PublishedScore",
-									"http://purl.org/lobid/lv#Legislation",
-									"http://purl.org/ontology/bibo/Image",
-									"http://purl.org/library/Game");
-					assertThat(facets.findValues("count").stream().map(e -> e.intValue())
-							.collect(Collectors.toList())).excludes(0);
-				});
+		running(testServer(3333), () -> {
+			String field = Application.TYPE_FIELD;
+			Promise<JsonNode> jsonPromise = Lobid.getFacets("köln", "", "", "", "",
+					"", "", "", "", "", "", field, "", "", "", "", "", "");
+			JsonNode facets = jsonPromise.get(Lobid.API_TIMEOUT);
+			assertThat(facets.findValues("term").stream().map(e -> e.asText())
+					.collect(Collectors.toList())).contains(
+							"http://purl.org/dc/terms/BibliographicResource",
+							"http://purl.org/ontology/bibo/Article",
+							"http://purl.org/ontology/bibo/Book",
+							"http://purl.org/ontology/bibo/Journal",
+							"http://purl.org/ontology/bibo/MultiVolumeBook",
+							"http://purl.org/ontology/bibo/Thesis",
+							"http://purl.org/lobid/lv#Miscellaneous",
+							"http://purl.org/ontology/bibo/Proceedings",
+							"http://purl.org/lobid/lv#EditedVolume",
+							"http://purl.org/lobid/lv#Biography",
+							"http://purl.org/lobid/lv#Festschrift",
+							"http://purl.org/ontology/bibo/Newspaper",
+							"http://purl.org/lobid/lv#Bibliography",
+							"http://purl.org/ontology/bibo/Series",
+							"http://purl.org/lobid/lv#OfficialPublication",
+							"http://purl.org/ontology/bibo/ReferenceSource",
+							"http://purl.org/ontology/mo/PublishedScore",
+							"http://purl.org/lobid/lv#Legislation",
+							"http://purl.org/ontology/bibo/Image",
+							"http://purl.org/library/Game");
+			assertThat(facets.findValues("count").stream().map(e -> e.intValue())
+					.collect(Collectors.toList())).excludes(0);
+		});
 	}
 
 	@Test
@@ -107,16 +81,14 @@ public class IntegrationTest {
 		String query = "buch";
 		int from = 0;
 		int size = 10;
-		running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT,
-				(TestBrowser browser) -> {
-					Content html =
-							views.html.search.render("[{}]", query, "", "", "", "", "", "",
-									"", "", "", from, size, 0L, "", "", "", "", "", "", "", "");
-					assertThat(Helpers.contentType(html)).isEqualTo("text/html");
-					String text = Helpers.contentAsString(html);
-					assertThat(text).contains("NWBib").contains("buch")
-							.contains("Sachsystematik").contains("Raumsystematik");
-				});
+		running(testServer(3333), () -> {
+			Content html = views.html.search.render("[{}]", query, "", "", "", "", "",
+					"", "", "", "", from, size, 0L, "", "", "", "", "", "", "", "");
+			assertThat(Helpers.contentType(html)).isEqualTo("text/html");
+			String text = Helpers.contentAsString(html);
+			assertThat(text).contains("NWBib").contains("buch")
+					.contains("Sachsystematik").contains("Raumsystematik");
+		});
 	}
 
 	@Test


### PR DESCRIPTION
Will resolve #306

- Fetch original SKOS classification in TTL format from URL
- Index into embedded Elasticsearch index if index does not exist
- Enable index-based integration tests for CI (now possible)

Deployed to staging, see:

- http://test.nwbib.de/search?q=köln (classification used by facets: 'Regionen', 'Orte')
- http://test.nwbib.de/HT018907075 (classification used by labels: 'Raumsystematik', 'Sachsystematik')
- http://test.nwbib.de/classification?t=Raumsystematik
- http://test.nwbib.de/classification?t=Sachsystematik