### PR TITLE
API fallback improvements for details view

### DIFF
--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -62,6 +62,9 @@ public class Lobid {
 				// Fall back to data 1.x if nothing found:
 				String fallbackUrl = String.format("%s/%s?format=full",
 						Application.CONFIG.getString("nwbib.api"), id);
+				Logger.warn(
+						"No response from Lobid API 2.0 URL '{}', falling back to API 1.x URL '{}'",
+						url, fallbackUrl);
 				DATA_2 = false; // required for processing individual fields
 				return cachedJsonCall(fallbackUrl);
 			}

--- a/app/views/tags/result_doc.scala.html
+++ b/app/views/tags/result_doc.scala.html
@@ -137,7 +137,7 @@
   @result_field("Schlagwörter", "subject", doc, TableRow.VALUES, valueLabel = gndEntities, param="subject")
   @result_field("Schlagwortfolge", "subjectChain", doc, TableRow.VALUES, valueLabel = Option(Seq()))
 
-  @result_field("Inhaltsangabe", "description", doc, TableRow.LINKS)
+  @if(Lobid.DATA_2) { @result_field("Inhaltsangabe", "description", doc, TableRow.LINKS) }
   @result_field("Inhaltsverzeichnis", "tableOfContents", doc, TableRow.LINKS)
   @result_field("Weitere Informationen", "isPrimaryTopicOf", doc, TableRow.LINKS, valueLabel = Option(Seq("hbz-Verbundkatalog")))
 }

--- a/app/views/tags/result_field.scala.html
+++ b/app/views/tags/result_field.scala.html
@@ -27,5 +27,5 @@
 	property,
 	param,
 	label,
-	multiSingleOrEmptySeq(jsonVal(property)).map(_.as[String]).sorted(Ordering[String].reverse),
+	multiSingleOrEmptySeq(jsonVal(property)).map(_.asOpt[String].getOrElse("--")).sorted(Ordering[String].reverse),
 	if(valueLabel.isEmpty){ Optional.empty() } else { Optional.of(valueLabel.get) }))


### PR DESCRIPTION
Will resolve #331

- Log information when falling back to API 1.x for details view
- Avoid error on full resource, just skip field value that failed
- Only show 'description' when using API 2.0 (wrong format in 1.x)