### PR TITLE
Support drill down within a facet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: java
 env:
-  - ACTIVATOR_VERSION=1.3.5
+  - ACTIVATOR_VERSION=1.3.10
 jdk: oraclejdk8
 before_script:
   - wget http://downloads.typesafe.com/typesafe-activator/${ACTIVATOR_VERSION}/typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
   - unzip typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
 script:
-  - ./activator-${ACTIVATOR_VERSION}-minimal/activator test
+  - ./activator-${ACTIVATOR_VERSION}-minimal/bin/activator "test-only tests.TravisTests"

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -639,14 +639,15 @@ public class Application extends Controller {
 		String rawPrefix =
 				Lobid.escapeUri(COVERAGE_FIELD.replace(".raw", "")) + ":";
 		if (currentParam.isEmpty()) {
-			return rawPrefix + quotedEscaped(term);
+			return rawPrefix + "(+" + quotedEscaped(term) + ")";
 		} else if (rawContains(currentParam, quotedEscaped(term))) {
-			String removedTerm =
-					currentParam.replace(rawPrefix, "").replace(quotedEscaped(term), "")
-							.replaceAll("\\A\\+|\\+\\z", "").replaceAll("\\++", "+");
-			return removedTerm.trim().isEmpty() ? "" : rawPrefix + removedTerm;
+			String removedTerm = currentParam.replace(rawPrefix, "")
+					.replace("+" + quotedEscaped(term), "")
+					.replaceAll("\\A\\+|\\+\\z", "").replaceAll("\\++", "+");
+			return removedTerm.trim().equals("()") ? "" : rawPrefix + removedTerm;
 		} else
-			return currentParam + "+" + quotedEscaped(term);
+			return currentParam.substring(0, currentParam.length() - 1) + "+"
+					+ quotedEscaped(term) + ")";
 	}
 
 	private static String quotedEscaped(String term) {
@@ -656,6 +657,8 @@ public class Application extends Controller {
 	private static boolean rawContains(String raw, String term) {
 		String[] split = raw.split(":");
 		String terms = split[split.length - 1];
+		terms =
+				terms.length() >= 2 ? terms.substring(1, terms.length() - 1) : terms;
 		return Arrays.asList(terms.split("\\+")).contains(term);
 	}
 

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -580,7 +580,8 @@ public class Application extends Controller {
 							"facets-labels.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
 							field, raw, q, person, name, id, publisher, set, word,
 							corporation, subject, issued, medium, nwbibspatial, nwbibsubject,
-							raw, owner, t, location);
+							raw, field.equals(ITEM_FIELD) ? "" : owner,
+							field.equals(TYPE_FIELD) ? "" : t, location);
 
 					@SuppressWarnings("unchecked")
 					List<Pair<JsonNode, String>> labelledFacets =

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -579,21 +579,8 @@ public class Application extends Controller {
 					String labelKey = String.format(
 							"facets-labels.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
 							field, raw, q, person, name, id, publisher, set, word,
-							corporation,
-							/*
-							 * facet values, include in key only if not the current facet,
-							 * except literal subjects, which can be combined with facet:
-							 */
-							field.equals(SUBJECT_FIELD) && subject.startsWith("http") ? ""
-									: subject,
-							field.equals(ISSUED_FIELD) ? "" : issued,
-							field.equals(MEDIUM_FIELD) ? "" : medium,
-							field.equals(NWBIB_SPATIAL_FIELD) ? "" : nwbibspatial,
-							field.equals(NWBIB_SUBJECT_FIELD) ? "" : nwbibsubject,
-							field.equals(COVERAGE_FIELD) ? "" : raw,
-							field.equals(ISSUED_FIELD) ? "" : owner,
-							field.equals(TYPE_FIELD) ? "" : t,
-							field.equals(SUBJECT_LOCATION_FIELD) ? "" : location);
+							corporation, subject.startsWith("http") ? "" : subject, issued,
+							medium, nwbibspatial, nwbibsubject, raw, owner, t, location);
 
 					@SuppressWarnings("unchecked")
 					List<Pair<JsonNode, String>> labelledFacets =

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -579,8 +579,8 @@ public class Application extends Controller {
 					String labelKey = String.format(
 							"facets-labels.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
 							field, raw, q, person, name, id, publisher, set, word,
-							corporation, subject.startsWith("http") ? "" : subject, issued,
-							medium, nwbibspatial, nwbibsubject, raw, owner, t, location);
+							corporation, subject, issued, medium, nwbibspatial, nwbibsubject,
+							raw, owner, t, location);
 
 					@SuppressWarnings("unchecked")
 					List<Pair<JsonNode, String>> labelledFacets =

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -531,7 +531,7 @@ public class Application extends Controller {
 			String mediumQuery = !field.equals(MEDIUM_FIELD) //
 					? medium : queryParam(medium, term);
 			String typeQuery = !field.equals(TYPE_FIELD) //
-					? t : withoutAndOperator(queryParam(t, term));
+					? t : queryParam(t, term);
 			String ownerQuery = !field.equals(ITEM_FIELD) //
 					? owner : withoutAndOperator(queryParam(owner, term));
 			String nwbibsubjectQuery = !field.equals(NWBIB_SUBJECT_FIELD) //
@@ -580,8 +580,7 @@ public class Application extends Controller {
 							"facets-labels.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
 							field, raw, q, person, name, id, publisher, set, word,
 							corporation, subject, issued, medium, nwbibspatial, nwbibsubject,
-							raw, field.equals(ITEM_FIELD) ? "" : owner,
-							field.equals(TYPE_FIELD) ? "" : t, location);
+							raw, field.equals(ITEM_FIELD) ? "" : owner, t, location);
 
 					@SuppressWarnings("unchecked")
 					List<Pair<JsonNode, String>> labelledFacets =

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -531,9 +531,9 @@ public class Application extends Controller {
 			String mediumQuery = !field.equals(MEDIUM_FIELD) //
 					? medium : queryParam(medium, term);
 			String typeQuery = !field.equals(TYPE_FIELD) //
-					? t : queryParam(t, term);
+					? t : withoutAndOperator(queryParam(t, term));
 			String ownerQuery = !field.equals(ITEM_FIELD) //
-					? owner : queryParam(owner, term);
+					? owner : withoutAndOperator(queryParam(owner, term));
 			String nwbibsubjectQuery = !field.equals(NWBIB_SUBJECT_FIELD) //
 					? nwbibsubject : queryParam(nwbibsubject, term);
 			String nwbibspatialQuery = !field.equals(NWBIB_SPATIAL_FIELD) //
@@ -623,11 +623,16 @@ public class Application extends Controller {
 	private static String queryParam(String currentParam, String term) {
 		if (currentParam.isEmpty())
 			return term;
-		else if (contains(currentParam, term))
-			return currentParam.replace(term, "").replaceAll("\\A,|,\\z", "")
-					.replaceAll(",+", ",");
-		else
-			return currentParam + "," + term;
+		else if (contains(currentParam, term)) {
+			String termRemoved = currentParam.replace(term, "")
+					.replaceAll("\\A,|,?\\z", "").replaceAll(",+", ",");
+			return termRemoved.equals("AND") ? "" : termRemoved;
+		} else
+			return withoutAndOperator(currentParam) + "," + term + ",AND";
+	}
+
+	private static String withoutAndOperator(String currentParam) {
+		return currentParam.replace(",AND", "");
 	}
 
 	/**

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -368,8 +368,6 @@ public class Lobid {
 										: Application.MAX_FACETS + "")
 						.setQueryParameter("corporation", corporation)//
 						.setQueryParameter("medium", medium)//
-						.setQueryParameter("t", t)//
-						.setQueryParameter("owner", owner)//
 						.setQueryParameter("nwbibspatial", nwbibspatial)//
 						.setQueryParameter("nwbibsubject", nwbibsubject)//
 						.setQueryParameter("location", locationPolygon(location))//
@@ -383,6 +381,10 @@ public class Lobid {
 		else
 			request = request.setQueryParameter("set",
 					Application.CONFIG.getString("nwbib.set"));
+		if (!field.equals(Application.TYPE_FIELD))
+			request = request.setQueryParameter("t", t);
+		if (!field.equals(Application.ITEM_FIELD))
+			request = request.setQueryParameter("owner", owner);
 		if (!raw.isEmpty()
 				&& !raw.contains(Lobid.escapeUri(Application.COVERAGE_FIELD)))
 			request = request.setQueryParameter("q", raw);

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -452,7 +452,8 @@ public class Lobid {
 	 */
 	public static String withoutUris(String queryValues) {
 		return Arrays.asList(queryValues.split(",")).stream()
-				.filter(s -> !s.startsWith("http://")).collect(Collectors.joining(","));
+				.filter(s -> !s.startsWith("http://") && !s.matches("AND|OR"))
+				.collect(Collectors.joining(","));
 	}
 
 	/**

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -448,13 +448,11 @@ public class Lobid {
 	/**
 	 * @param queryValues The value string of the query, e.g. <br/>
 	 *          `"Eisenbahnlinie,http://d-nb.info/gnd/4129465-8"`
-	 * @return A fully labelled version of the given query values, e.g. <br/>
-	 *         `"Eisenbahnlinie,Bahnhof"`
+	 * @return The given string, without URIs, e.g.`"Eisenbahnlinie"`
 	 */
-	public static String labelledQueryValues(String queryValues) {
-		return Arrays.asList(queryValues.split(",")).stream().map(
-				s -> s.startsWith("http://") ? facetLabel(Arrays.asList(s), "", "") : s)
-				.collect(Collectors.joining(","));
+	public static String withoutUris(String queryValues) {
+		return Arrays.asList(queryValues.split(",")).stream()
+				.filter(s -> !s.startsWith("http://")).collect(Collectors.joining(","));
 	}
 
 	/**

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -366,7 +366,14 @@ public class Lobid {
 						.setQueryParameter("size",
 								field.equals(Application.ITEM_FIELD) ? "9999"
 										: Application.MAX_FACETS + "")
-						.setQueryParameter("corporation", corporation);
+						.setQueryParameter("corporation", corporation)//
+						.setQueryParameter("medium", medium)//
+						.setQueryParameter("t", t)//
+						.setQueryParameter("owner", owner)//
+						.setQueryParameter("nwbibspatial", nwbibspatial)//
+						.setQueryParameter("nwbibsubject", nwbibsubject)//
+						.setQueryParameter("location", locationPolygon(location))//
+						.setQueryParameter("issued", issued);
 		if (!q.isEmpty())
 			request = request.setQueryParameter("word", preprocess(q));
 		else if (!word.isEmpty())
@@ -376,26 +383,11 @@ public class Lobid {
 		else
 			request = request.setQueryParameter("set",
 					Application.CONFIG.getString("nwbib.set"));
-		if (!field.equals(Application.MEDIUM_FIELD))
-			request = request.setQueryParameter("medium", medium);
-		if (!field.equals(Application.TYPE_FIELD))
-			request = request.setQueryParameter("t", t);
-		if (!field.equals(Application.ITEM_FIELD))
-			request = request.setQueryParameter("owner", owner);
-		if (!field.equals(Application.NWBIB_SPATIAL_FIELD))
-			request = request.setQueryParameter("nwbibspatial", nwbibspatial);
-		if (!field.equals(Application.COVERAGE_FIELD) || (!raw.isEmpty()
-				&& !raw.contains(Lobid.escapeUri(Application.COVERAGE_FIELD))))
+		if (!raw.isEmpty()
+				&& !raw.contains(Lobid.escapeUri(Application.COVERAGE_FIELD)))
 			request = request.setQueryParameter("q", raw);
-		if (!field.equals(Application.NWBIB_SUBJECT_FIELD))
-			request = request.setQueryParameter("nwbibsubject", nwbibsubject);
-		if (!field.equals(Application.SUBJECT_FIELD) || !field.startsWith("http"))
+		if (!field.startsWith("http"))
 			request = request.setQueryParameter("subject", subject);
-		if (!field.equals(Application.SUBJECT_LOCATION_FIELD))
-			request =
-					request.setQueryParameter("location", locationPolygon(location));
-		if (!field.equals(Application.ISSUED_FIELD))
-			request = request.setQueryParameter("issued", issued);
 		String url = request.getUrl();
 		Map<String, Collection<String>> parameters = request.getQueryParameters();
 		Logger.info("Facets request URL {}, query params {} ", url, parameters);

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -371,7 +371,8 @@ public class Lobid {
 						.setQueryParameter("nwbibspatial", nwbibspatial)//
 						.setQueryParameter("nwbibsubject", nwbibsubject)//
 						.setQueryParameter("location", locationPolygon(location))//
-						.setQueryParameter("issued", issued);
+						.setQueryParameter("issued", issued)//
+						.setQueryParameter("t", t);
 		if (!q.isEmpty())
 			request = request.setQueryParameter("word", preprocess(q));
 		else if (!word.isEmpty())
@@ -381,8 +382,6 @@ public class Lobid {
 		else
 			request = request.setQueryParameter("set",
 					Application.CONFIG.getString("nwbib.set"));
-		if (!field.equals(Application.TYPE_FIELD))
-			request = request.setQueryParameter("t", t);
 		if (!field.equals(Application.ITEM_FIELD))
 			request = request.setQueryParameter("owner", owner);
 		if (!raw.isEmpty()

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -446,6 +446,18 @@ public class Lobid {
 	}
 
 	/**
+	 * @param queryValues The value string of the query, e.g. <br/>
+	 *          `"Eisenbahnlinie,http://d-nb.info/gnd/4129465-8"`
+	 * @return A fully labelled version of the given query values, e.g. <br/>
+	 *         `"Eisenbahnlinie,Bahnhof"`
+	 */
+	public static String labelledQueryValues(String queryValues) {
+		return Arrays.asList(queryValues.split(",")).stream().map(
+				s -> s.startsWith("http://") ? facetLabel(Arrays.asList(s), "", "") : s)
+				.collect(Collectors.joining(","));
+	}
+
+	/**
 	 * @param uris Some URIs
 	 * @param field The ES field to facet over
 	 * @param label A label for the facet

--- a/app/views/tags/facets.scala.html
+++ b/app/views/tags/facets.scala.html
@@ -30,7 +30,7 @@
       </script>
       <h5 id="@field.hashCode.abs-header">
         @facetToggle("facets-ul-" + field.hashCode.abs.toString){@facet}
-        @facetLabel(current, current.split("[,+]").size + " ausgewählt")
+        @facetLabel(current, "ausgewählt", field.hashCode.abs + "-count", current.split("[,+]").size.toString)
       </h5>
       <ul class="facet" id="facets-ul-@field.hashCode.abs">
           <script>
@@ -83,6 +83,8 @@
                    ul.append("</div>");
                  }
                }
+               var active = $("#facets-ul-@field.hashCode.abs li.active");
+               $("#@field.hashCode.abs-count").text(active.length);
               $("#facets-loading-@field.hashCode.abs").remove();
               @if(field==Application.ISSUED_FIELD){ @issued_facet(issued) }
             },
@@ -96,9 +98,9 @@
   </div>
 }
 
-@facetLabel(current: String, label: String) = {
+@facetLabel(current: String, label: String, activeCountId: String = "", currentCount: String = "") = {
   @if(!current.isEmpty){
-    <span class="badge" id="facet-filter">@label</span> 
+     <span class="badge" id="facet-filter"><span id="@activeCountId">@currentCount</span> @label</span>
      <a href="@nwbib.routes.Application.search(q,person,name,if (subject==current) "" else subject,id,publisher,if(issued==current) "" else issued,if (medium==current) "" else medium,if(nwbibspatial==current) "" else nwbibspatial,if(nwbibsubject==current) "" else nwbibsubject,from,size,if (owner==current) "" else owner,if (t==current) "" else t,sortParam,set=set,location=(if (location==current) "" else location),word=word,corporation=corporation,raw=(if (raw.split(":").last==current) "" else raw)).toString" title="Filter entfernen"><span class="octicon octicon-x"></span></a> 
    }
 }

--- a/app/views/tags/facets.scala.html
+++ b/app/views/tags/facets.scala.html
@@ -107,13 +107,17 @@
 @facetLabel(current: String, label: String, activeCountId: String = "", currentCount: String = "") = {
   @if(!current.isEmpty){
      <span class="badge" id="facet-filter"><span id="@activeCountId">@currentCount</span> @label</span>
-     <a href="@nwbib.routes.Application.search(q,person,name,if (subject==current) "" else subject,id,publisher,if(issued==current) "" else issued,if (medium==current) "" else medium,if(nwbibspatial==current) "" else nwbibspatial,if(nwbibsubject==current) "" else nwbibsubject,from,size,if (owner==current) "" else owner,if (t==current) "" else t,sortParam,set=set,location=(if (location==current) "" else location),word=word,corporation=corporation,raw=(if (raw.split(":").last==current) "" else raw)).toString" title="Filter entfernen"><span class="octicon octicon-x"></span></a> 
+     <a href="@nwbib.routes.Application.search(q,person,name,if (urisOnly(subject)==current) "" else subject,id,publisher,if(issued==current) "" else issued,if (medium==current) "" else medium,if(nwbibspatial==current) "" else nwbibspatial,if(nwbibsubject==current) "" else nwbibsubject,from,size,if (owner==current) "" else owner,if (t==current) "" else t,sortParam,set=set,location=(if (location==current) "" else location),word=word,corporation=corporation,raw=(if (raw.split(":").last==current) "" else raw)).toString" title="Filter entfernen"><span class="octicon octicon-x"></span></a> 
    }
 }
 
 @locationLabel(loc:String)=@{
   val isLatLon = loc.contains(",")
   if(isLatLon) {views.ReverseGeoLookup.of(loc)} else {loc}
+}
+
+@urisOnly(s: String)=@{
+	s.split(",").filter(_.startsWith("http")).mkString(",")
 }
 
 <div class="col-md-3 hide-in-print" style="font-size: small">
@@ -134,7 +138,7 @@
   <div class="row facet"><div class="col-md-12">@facets("Regionen", Application.NWBIB_SPATIAL_FIELD, nwbibspatial)</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Orte", Application.COVERAGE_FIELD, raw.split(":").last)</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Sachgebiete", Application.NWBIB_SUBJECT_FIELD, nwbibsubject)</div></div>
-  <div class="row facet"><div class="col-md-12">@defining(subject.split(",").filter(_.startsWith("http")).mkString(",")){ subjectUris => @facets("Schlagwörter", Application.SUBJECT_FIELD, if(!subjectUris.isEmpty) subjectUris else "", "dropup")}</div></div>
+  <div class="row facet"><div class="col-md-12">@facets("Schlagwörter", Application.SUBJECT_FIELD, if(!urisOnly(subject).isEmpty) urisOnly(subject) else "", "dropup")</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Medientypen", Application.MEDIUM_FIELD, medium, "dropup")</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Publikationstypen", Application.TYPE_FIELD, t, "dropup")</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Bestand in Bibliotheken", Application.ITEM_FIELD, owner, "dropup")</div></div>

--- a/app/views/tags/facets.scala.html
+++ b/app/views/tags/facets.scala.html
@@ -128,7 +128,7 @@
   <div class="row facet"><div class="col-md-12">@facets("Regionen", Application.NWBIB_SPATIAL_FIELD, nwbibspatial)</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Orte", Application.COVERAGE_FIELD, raw.split(":").last)</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Sachgebiete", Application.NWBIB_SUBJECT_FIELD, nwbibsubject)</div></div>
-  <div class="row facet"><div class="col-md-12">@facets("Schlagwörter", Application.SUBJECT_FIELD, if(subject.startsWith("http")) subject else "", "dropup")</div></div>
+  <div class="row facet"><div class="col-md-12">@defining(subject.split(",").filter(_.startsWith("http")).mkString(",")){ subjectUris => @facets("Schlagwörter", Application.SUBJECT_FIELD, if(!subjectUris.isEmpty) subjectUris else "", "dropup")}</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Medientypen", Application.MEDIUM_FIELD, medium, "dropup")</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Publikationstypen", Application.TYPE_FIELD, t, "dropup")</div></div>
   <div class="row facet"><div class="col-md-12">@facets("Bestand in Bibliotheken", Application.ITEM_FIELD, owner, "dropup")</div></div>

--- a/app/views/tags/facets.scala.html
+++ b/app/views/tags/facets.scala.html
@@ -30,7 +30,9 @@
       </script>
       <h5 id="@field.hashCode.abs-header">
         @facetToggle("facets-ul-" + field.hashCode.abs.toString){@facet}
-        @facetLabel(current, "ausgewählt", field.hashCode.abs + "-count", current.split("[,+]").size.toString)
+        <span id="@field.hashCode.abs-label">
+          @facetLabel(current, "ausgewählt", field.hashCode.abs + "-count", current.split("[,+]").size.toString)
+        </span>
       </h5>
       <ul class="facet" id="facets-ul-@field.hashCode.abs">
           <script>
@@ -84,7 +86,11 @@
                  }
                }
                var active = $("#facets-ul-@field.hashCode.abs li.active");
-               $("#@field.hashCode.abs-count").text(active.length);
+               if(active.length == 0) {
+                 $("#@field.hashCode.abs-label").hide();
+               } else {
+                 $("#@field.hashCode.abs-count").text(active.length);
+               }
               $("#facets-loading-@field.hashCode.abs").remove();
               @if(field==Application.ISSUED_FIELD){ @issued_facet(issued) }
             },

--- a/app/views/tags/search_advanced.scala.html
+++ b/app/views/tags/search_advanced.scala.html
@@ -3,6 +3,7 @@
 @(label:String, q:String = "", person: String = "", name: String = "", subject: String = "", nwbibspatial: String = "", nwbibsubject: String = "", id: String = "", publisher: String = "", issued: String = "", sortParam: String = "", word: String = "", corporation: String = "")
 
 @import scala.collection.immutable.TreeMap
+@import controllers.nwbib.Lobid
 
 <script>
 function addSearchWidget(c){
@@ -75,7 +76,7 @@ function suggests(term){
 
 @helper.form(action = controllers.nwbib.routes.Application.search(), 
     'id -> "nwbib-form", 'role -> "form", 'class -> "form-inline") {
-  @defining(TreeMap("name"->name,"person"->person,"corporation"->corporation,"subject"->subject, "id"->id,"publisher"->publisher,"word"->word).filter({case (k,v) => !v.isEmpty && (k != "subject" || (k == "subject" && !v.startsWith("http")))})) { fields =>
+  @defining(TreeMap("name"->name,"person"->person,"corporation"->corporation,"subject"->Lobid.labelledQueryValues(subject), "id"->id,"publisher"->publisher,"word"->word).filter({case (k,v) => !v.isEmpty && (k != "subject" || (k == "subject" && !v.startsWith("http")))})) { fields =>
   @for(((k,v),i)<- (if(fields.isEmpty) TreeMap("q" -> "") else fields).zipWithIndex){
   <div class="search-field row" id="search-field-@i">
       <div class="form-group col col-md-2">

--- a/app/views/tags/search_advanced.scala.html
+++ b/app/views/tags/search_advanced.scala.html
@@ -76,7 +76,7 @@ function suggests(term){
 
 @helper.form(action = controllers.nwbib.routes.Application.search(), 
     'id -> "nwbib-form", 'role -> "form", 'class -> "form-inline") {
-  @defining(TreeMap("name"->name,"person"->person,"corporation"->corporation,"subject"->Lobid.labelledQueryValues(subject), "id"->id,"publisher"->publisher,"word"->word).filter({case (k,v) => !v.isEmpty && (k != "subject" || (k == "subject" && !v.startsWith("http")))})) { fields =>
+  @defining(TreeMap("name"->name,"person"->person,"corporation"->corporation,"subject"->Lobid.withoutUris(subject), "id"->id,"publisher"->publisher,"word"->word).filter({case (k,v) => !v.isEmpty && (k != "subject" || (k == "subject" && !v.startsWith("http")))})) { fields =>
   @for(((k,v),i)<- (if(fields.isEmpty) TreeMap("q" -> "") else fields).zipWithIndex){
   <div class="search-field row" id="search-field-@i">
       <div class="form-group col col-md-2">

--- a/test/tests/AllTests.java
+++ b/test/tests/AllTests.java
@@ -1,0 +1,20 @@
+package tests;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * All tests, including long running tests and integration tests with
+ * dependencies on external services. For quick, self-contained tests see
+ * {@link TravisTests}.
+ * 
+ * @author Fabian Steeg (fsteeg)
+ *
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ ApplicationTest.class, InternalIntegrationTest.class,
+		ExternalIntegrationTest.class, InputStringsTest.class })
+public class AllTests {
+	//
+}

--- a/test/tests/ExternalIntegrationTest.java
+++ b/test/tests/ExternalIntegrationTest.java
@@ -1,0 +1,123 @@
+/* Copyright 2014 Fabian Steeg, hbz. Licensed under the GPLv2 */
+
+package tests;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static play.test.Helpers.running;
+import static play.test.Helpers.testServer;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import controllers.nwbib.Application;
+import controllers.nwbib.Lobid;
+import play.libs.F.Promise;
+import play.mvc.Http;
+import play.test.Helpers;
+import play.twirl.api.Content;
+import views.ReverseGeoLookup;
+
+/**
+ * See http://www.playframework.com/documentation/2.3.x/JavaFunctionalTest
+ */
+@SuppressWarnings("javadoc")
+public class ExternalIntegrationTest {
+
+	@Before
+	public void setUp() throws Exception {
+		Map<String, String> flashData = Collections.emptyMap();
+		Map<String, Object> argData = Collections.emptyMap();
+		play.api.mvc.RequestHeader header = mock(play.api.mvc.RequestHeader.class);
+		Http.Request request = mock(Http.Request.class);
+		Http.Context context =
+				new Http.Context(2L, header, request, flashData, flashData, argData);
+		Http.Context.current.set(context);
+	}
+
+	@Test
+	public void testFacets() {
+		running(testServer(3333), () -> {
+			String field = Application.TYPE_FIELD;
+			Promise<JsonNode> jsonPromise = Lobid.getFacets("köln", "", "", "", "",
+					"", "", "", "", "", "", field, "", "", "", "", "", "");
+			JsonNode facets = jsonPromise.get(Lobid.API_TIMEOUT);
+			assertThat(facets.findValues("term").stream().map(e -> e.asText())
+					.collect(Collectors.toList())).contains(
+							"http://purl.org/dc/terms/BibliographicResource",
+							"http://purl.org/ontology/bibo/Article",
+							"http://purl.org/ontology/bibo/Book",
+							"http://purl.org/ontology/bibo/Journal",
+							"http://purl.org/ontology/bibo/MultiVolumeBook",
+							"http://purl.org/ontology/bibo/Thesis",
+							"http://purl.org/lobid/lv#Miscellaneous",
+							"http://purl.org/ontology/bibo/Proceedings",
+							"http://purl.org/lobid/lv#EditedVolume",
+							"http://purl.org/lobid/lv#Biography",
+							"http://purl.org/lobid/lv#Festschrift",
+							"http://purl.org/ontology/bibo/Newspaper",
+							"http://purl.org/lobid/lv#Bibliography",
+							"http://purl.org/ontology/bibo/Series",
+							"http://purl.org/lobid/lv#OfficialPublication",
+							"http://purl.org/ontology/bibo/ReferenceSource",
+							"http://purl.org/ontology/mo/PublishedScore",
+							"http://purl.org/lobid/lv#Legislation",
+							"http://purl.org/ontology/bibo/Image",
+							"http://purl.org/library/Game");
+			assertThat(facets.findValues("count").stream().map(e -> e.intValue())
+					.collect(Collectors.toList())).excludes(0);
+		});
+	}
+
+	@Test
+	public void renderTemplate() {
+		String query = "buch";
+		int from = 0;
+		int size = 10;
+		running(testServer(3333), () -> {
+			Content html = views.html.search.render("[{}]", query, "", "", "", "", "",
+					"", "", "", "", from, size, 0L, "", "", "", "", "", "", "", "");
+			assertThat(Helpers.contentType(html)).isEqualTo("text/html");
+			String text = Helpers.contentAsString(html);
+			assertThat(text).contains("NWBib").contains("buch")
+					.contains("Sachsystematik").contains("Raumsystematik");
+		});
+	}
+
+	@Test
+	public void sizeRequest() {
+		running(testServer(3333), () -> {
+			Long hits = Lobid
+					.getTotalHits("@graph.http://purl.org/lobid/lv#multiVolumeWork.@id",
+							"http://lobid.org/resource/HT018486420", "")
+					.get(Lobid.API_TIMEOUT);
+			assertThat(hits).isGreaterThan(0);
+			hits = Lobid
+					.getTotalHits("@graph.http://purl.org/lobid/lv#series.@id",
+							"http://lobid.org/resource/HT002091108", "")
+					.get(Lobid.API_TIMEOUT);
+			assertThat(hits).isGreaterThan(0);
+			hits = Lobid
+					.getTotalHits("@graph.http://purl.org/lobid/lv#containedIn.@id",
+							"http://lobid.org/resource/HT001387709", "")
+					.get(Lobid.API_TIMEOUT);
+			assertThat(hits).isGreaterThan(0);
+		});
+	}
+
+	@Test
+	public void reverseGeoLookup() {
+		running(testServer(3333), () -> {
+			assertEquals("Menden (Sauerland)",
+					ReverseGeoLookup.of("51.433333391323686,7.800000105053186"));
+		});
+	}
+
+}

--- a/test/tests/InternalIntegrationTest.java
+++ b/test/tests/InternalIntegrationTest.java
@@ -3,7 +3,6 @@
 package tests;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static play.test.Helpers.running;
 import static play.test.Helpers.testServer;
@@ -23,13 +22,12 @@ import play.libs.F.Promise;
 import play.mvc.Http;
 import play.test.Helpers;
 import play.twirl.api.Content;
-import views.ReverseGeoLookup;
 
 /**
  * See http://www.playframework.com/documentation/2.3.x/JavaFunctionalTest
  */
 @SuppressWarnings("javadoc")
-public class IntegrationTest {
+public class InternalIntegrationTest {
 
 	@Before
 	public void setUp() throws Exception {
@@ -109,14 +107,6 @@ public class IntegrationTest {
 							"http://lobid.org/resource/HT001387709", "")
 					.get(Lobid.API_TIMEOUT);
 			assertThat(hits).isGreaterThan(0);
-		});
-	}
-
-	@Test
-	public void reverseGeoLookup() {
-		running(testServer(3333), () -> {
-			assertEquals("Menden (Sauerland)",
-					ReverseGeoLookup.of("51.433333391323686,7.800000105053186"));
 		});
 	}
 

--- a/test/tests/TravisTests.java
+++ b/test/tests/TravisTests.java
@@ -1,0 +1,19 @@
+package tests;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * All quick, self-contained tests for running in Travis CI. For running all
+ * tests, including long running tests and integration tests with dependencies
+ * on external services see {@link AllTests}.
+ * 
+ * @author Fabian Steeg (fsteeg)
+ *
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ ApplicationTest.class, InternalIntegrationTest.class })
+public class TravisTests {
+	//
+}


### PR DESCRIPTION
Will resolve #336

Include current facet selection when getting other facet values. Makes the facet self restricting: it shows only values that appear with the current selection. Makes the facet behavior more consistent, as facets in general narrow down the current results.

Also fixes the problem of missing selected values which were not part of the top results with the previous behavior.