### PR TITLE
Reduce minZoom setting on coverage map

### DIFF
--- a/app/views/tags/coverage_map.scala.html
+++ b/app/views/tags/coverage_map.scala.html
@@ -20,7 +20,7 @@ var nrw = new L.LatLng(51.45, 7.7)
 var map = new L.Map("map-coverage", {
     center: nrw,
     zoom: 6,
-    minZoom: 6,
+    minZoom: 4,
     maxZoom: 13,
     scrollWheelZoom: true,
     attributionControl: false,


### PR DESCRIPTION
Will resolve #356

Centering was correct, but content was cut off.

Deployed to production:
http://test.nwbib.de/search?nwbibsubject=http%3A%2F%2Fpurl.org%2Flobid%2Fnwbib%23s102070

Underlying issue is that 5 resources are located in the wrong `Altenberg` (see [1]):
http://test.nwbib.de/search?nwbibsubject=http%3A%2F%2Fpurl.org%2Flobid%2Fnwbib%23s102070&location=50.75000007636845%2C13.750000018626451

Probably nothing we'll still fix in Lobid 1.x. Data 2.0 contains no locations yet, we might reuse the approach from lobid-organisations for Lobid 2.0, based on the Mapzen API [2] (ping #83).

[1] https://en.wikipedia.org/wiki/Altenberg
[2] https://github.com/hbz/lobid-organisations/commit/25bb79b370ca86e769f544bbb4be5e750d2c1934