### PR TITLE
Revert recent data 2.0 specific changes, use API 1.x

### DIFF
--- a/app/views/TableRow.java
+++ b/app/views/TableRow.java
@@ -33,7 +33,7 @@ public enum TableRow {
 		public String process(JsonNode doc, String property, String param,
 				String label, List<String> values, Optional<List<String>> keys) {
 			List<String> vs = values;
-			if (doc.has("coverage")) { // see https://github.com/hbz/nwbib/issues/276
+			if (doc.findValue("coverage") != null) { // https://github.com/hbz/nwbib/issues/276
 				List<String> remove = Arrays.asList(//
 						"http://purl.org/lobid/nwbib-spatial#n10",
 						"http://purl.org/lobid/nwbib-spatial#n12",

--- a/app/views/tags/result_doc.scala.html
+++ b/app/views/tags/result_doc.scala.html
@@ -31,15 +31,15 @@
 }
 
 @nestedIds(property: String) = @{
-	(doc\property).asOpt[Seq[JsValue]].getOrElse(Seq()).map((v: JsValue) => (v \ "id").asOpt[String].getOrElse("No id in " + v))
+	(doc\\property).last.asOpt[Seq[JsValue]].getOrElse(Seq()).map((v: JsValue) => (v \ "id").asOpt[String].getOrElse("No id in " + v))
 }
 
 @singleOrMultiString(property: String) = @{
-	(doc\property).asOpt[Seq[String]].getOrElse(Seq((doc\property).asOpt[String].getOrElse("--")))
+	(doc\\property).last.asOpt[Seq[String]].getOrElse(Seq((doc\\property).last.asOpt[String].getOrElse("--")))
 }
 
 @with_icon(label: String, property: String, fullField: String) = {
-  @if((doc\property).asOpt[JsValue].isDefined) {
+  @if(!(doc\\property).isEmpty) {
     @defining(if(Lobid.DATA_2 && property != "type") { nestedIds(property) } else { singleOrMultiString(property) }){ v =>
       <tr><td>@label</td><td><span class="@Lobid.facetIcon(v,fullField)"></span> @Lobid.facetLabel(v,fullField,"")</td></tr>
     }

--- a/conf/nwbib.conf
+++ b/conf/nwbib.conf
@@ -6,7 +6,7 @@ nwbib.set="http://lobid.org/resource/NWBib"
 
 # Feature toggle: use lobid 2.0 data for presentation
 feature.lobid2 {
-	enabled=true
+	enabled=false
 	indexUrlFormat="http://lobid.org/resources/%s"
 }
 
@@ -74,7 +74,7 @@ type.labels={
 }
 
 medium.labels={
-    "http://rdvocab.info/termList/RDAproductionMethod/#1010" : ["Print", "glyphicon glyphicon-text-background", 0],
+    "http://rdvocab.info/termList/RDAproductionMethod/1010" : ["Print", "glyphicon glyphicon-text-background", 0],
     "http://rdvocab.info/termList/RDACarrierType/1010" : ["Elektronisch","octicon octicon-database", 1],
     "http://rdvocab.info/termList/RDACarrierType/1018" : ["Online","octicon octicon-radio-tower", 2],
     "http://purl.org/lobid/lv#Miscellaneous" : ["Sonstige","octicon octicon-question", 3],


### PR DESCRIPTION
Will resolve #377

Deployed to staging, see:

http://test.nwbib.de/HT013064214
http://test.nwbib.de/HT016287608
http://test.nwbib.de/HT006919326
http://test.nwbib.de/HT002732102
http://test.nwbib.de/HT016014462

To avoid redundant work, @acka47 and I agreed offline that we will keep NWBib on API 1.x for now, and move it over to 2.0 as part of https://github.com/hbz/nwbib/issues/262, after lobid-resources-web has completed the switch to 2.0 (see https://github.com/hbz/lobid-resources-web/issues/8).