### PR TITLE
Update SPARQL query

### DIFF
--- a/conf/wikidata.sparql
+++ b/conf/wikidata.sparql
@@ -7,24 +7,26 @@ SELECT DISTINCT
 ?dissolutionDate
 (group_concat(distinct ?hasPart; separator = ", ") as ?parts)
 WHERE {
-  hint:Query hint:optimizer "None".
-  { ?item wdt:P131* wd:Q1198 .
-       { ?item wdt:P31 wd:Q829277 . } # Regierungsbezirk in NRW
-   UNION
-       { ?item wdt:P31 wd:Q106658 . } # Landkreis
-   UNION
-       { ?item wdt:P31 wd:Q262166 . } # Gemeinde
-   UNION
-       { ?item wdt:P31 wd:Q22865 . } # kreisfreie Stadt
-   UNION
-       { ?item wdt:P31 wd:Q253019 . } # Ortsteil
-   UNION
-       { ?item wdt:P31 wd:Q1852178 . } # Stadtteil von Düsseldorf
-   UNION
-       { ?item wdt:P31 wd:Q15632166 . } # Stadtteil von Köln
-   UNION
-       { ?item wdt:P31/wdt:P279*  wd:Q4286337 } # Stadtbezirk, für Geocache auskommentieren
-  }
+           { ?item wdt:P131* wd:Q1198 . }
+      UNION
+           { ?item p:P131 [ ps:P131 wd:Q1198 ] . }
+           { ?item p:P31 [ ps:P31 wd:Q829277 ] . } # Regierungsbezirk in NRW
+       UNION
+           { ?item p:P31 [ ps:P31 wd:Q106658 ] . } # Landkreis
+       UNION
+           { ?item p:P31 [ ps:P31 wd:Q262166 ] . } # Gemeinde
+       UNION
+           { ?item p:P31 [ ps:P31 wd:Q22865 ] . } # kreisfreie Stadt
+       UNION
+           { ?item p:P31 [ ps:P31 wd:Q253019 ]. } # Ortsteil
+       UNION
+           { ?item p:P31 [ ps:P31 wd:Q1852178 ] . } # Stadteil von Düsseldorf
+       UNION
+           { ?item p:P31 [ ps:P31 wd:Q15632166 ] . } # Stadtteil von Köln
+       UNION
+           { ?item wdt:P31/wdt:P279*  wd:Q4286337 } # Stadtbezirk, für Geocache auskommentieren
+       UNION
+           { ?item p:P31 [ ps:P31 wd:Q4286337 ] . }
   SERVICE wikibase:label {  bd:serviceParam wikibase:language "de" }
   OPTIONAL { ?item wdt:P227 ?gnd }
   OPTIONAL { ?item wdt:P576 ?dissolutionDate }


### PR DESCRIPTION
Fixes #431. The old SPARQL query timed out when I tried it today. (I think because of the `hint:Query hint:optimizer "None".` clause.) So it was time to update this anyway.