### PR TITLE
Tweak spatial classification breadcrumb view

### DIFF
--- a/app/controllers/nwbib/Classification.java
+++ b/app/controllers/nwbib/Classification.java
@@ -271,19 +271,34 @@ public class Classification {
 	}
 
 	/**
-	 * @param uri The NWBib classificationURI
+	 * @param uri The NWBib classification URI
 	 * @param type The ES classification type (see {@link Classification.Type})
-	 * @return The label for the given URI
+	 * @return The label for the given classification URI
 	 */
-	public static String label(String uri, String type) {
+	public static String label(String uri, Type type) {
+		return getValueFromIndex(uri, type.elasticsearchType,
+				"http://www.w3.org/2004/02/skos/core#prefLabel");
+	}
+
+	/**
+	 * @param uri The NWBib classification URI
+	 * @param type The ES classification type (see {@link Classification.Type})
+	 * @return The notation for the given classification URI
+	 */
+	public static String notation(String uri, Type type) {
+		return getValueFromIndex(uri, type.elasticsearchType,
+				"http://www.w3.org/2004/02/skos/core#notation");
+	}
+
+	private static String getValueFromIndex(String uri, String type,
+			String field) {
 		try {
 			String response =
 					client.prepareGet(INDEX, type, uri).get().getSourceAsString();
 			if (response != null) {
-				String textValue = Json.parse(response)
-						.findValue("http://www.w3.org/2004/02/skos/core#prefLabel")
-						.findValue("@value").textValue();
-				return textValue != null ? textValue : "";
+				JsonNode resultNode = Json.parse(response).findValue(field);
+				return resultNode != null ? resultNode.findValue("@value").textValue()
+						: "";
 			}
 		} catch (Throwable t) {
 			Logger.error(

--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.html.HtmlEscapers;
 
+import controllers.nwbib.Classification.Type;
 import play.Logger;
 import play.Play;
 import play.cache.Cache;
@@ -407,9 +408,8 @@ public class Lobid {
 		if (cachedResult != null) {
 			return cachedResult;
 		}
-		String type =
-				uri.contains("spatial") ? Classification.Type.SPATIAL.elasticsearchType
-						: Classification.Type.NWBIB.elasticsearchType;
+		Type type = uri.contains("spatial") ? Classification.Type.SPATIAL
+				: Classification.Type.NWBIB;
 		String label =
 				Classification.label(Classification.toPurlNamespace(uri), type);
 		label = HtmlEscapers.htmlEscaper().escape(label);

--- a/app/views/tags/breadcrumb.scala.html
+++ b/app/views/tags/breadcrumb.scala.html
@@ -2,6 +2,7 @@
 
 @import controllers.nwbib.Lobid
 @import controllers.nwbib.Classification
+@import controllers.nwbib.Classification.Type
 @import controllers.nwbib.WikidataLocations
 
 @(nwbibsubject: String, nwbibspatial: String, person:String="", name:String="", subject:String="", id:String="", publisher:String="", issued:String="", medium: String="", owner: String="", t: String="", location: String="", word: String="", corporation: String="", raw: String="", search: Boolean = false)
@@ -10,7 +11,7 @@
 	@if(Lobid.isWikidata(uri)) {
 		@defining(WikidataLocations.label(uri)) { label =>
 		<a title='@uri.split("#").last @WikidataLocations.label(uri)' href='@if(label.startsWith("http")){@label}else{@nwbib.routes.Application.spatial()#@uri.split("#").last}'>
-			@label
+			<span style='color: #777777'>@Classification.notation(uri, Type.SPATIAL)</span> @label
 		</a>
 		}
 	} else {
@@ -30,9 +31,9 @@
 			@labels(nwbibspatial)
 		} else {
 			@defining(Classification.pathTo((if(!nwbibsubject.isEmpty) nwbibsubject else nwbibspatial))) { path => 
-				@defining(path.takeWhile(_.contains("spatial#N"))) { withNotation =>
-					@if(!withNotation.isEmpty){@labels(withNotation.last) &gt;}
-					@for(segment <- path.dropWhile(_.contains("spatial#N"))) {
+				@defining(path.takeWhile(!Classification.notation(_, Type.SPATIAL).isEmpty())) { withNotation =>
+					@if(!withNotation.isEmpty){@labels(withNotation.last) @if(path.last != withNotation.last) {&gt;}}
+					@for(segment <- path.dropWhile(!Classification.notation(_, Type.SPATIAL).isEmpty())) {
 						@labels(segment) @if(segment != path.last) {&gt;}
 					}
 				}

--- a/test/tests/ApplicationTest.java
+++ b/test/tests/ApplicationTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import controllers.nwbib.Classification;
+import controllers.nwbib.Classification.Type;
 import controllers.nwbib.Lobid;
 import play.libs.Json;
 
@@ -40,8 +41,9 @@ public class ApplicationTest {
 
 	@Test
 	public void classificationLabelNotAvailable() {
-		assertThat(Classification.label("https://nwbib.de/spatial#N58", "no-type"))
-				.as("empty label").isEqualTo("");
+		assertThat(
+				Classification.label("https://nwbib.de/spatial#N58", Type.SPATIAL))
+						.as("empty label").isEqualTo("");
 	}
 
 	@Test


### PR DESCRIPTION
Check if notation exists by using index data, not URI structure
(concepts represented by URIs with Q-IDs can now have notations)

Will resolve https://github.com/hbz/nwbib/issues/480