### PR TITLE
Update "Über die NWBib" link

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -71,7 +71,7 @@
                       <li @if(title=="NWBib: Kontakt"){class="active"} class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" title="Info"><span class="glyphicon glyphicon-info-sign"></span><b class="caret"></b></a>
                         <ul class="dropdown-menu">
-                          <li><a href="http://www.landesbibliothek-nrw.de/aufgaben/nrw_bibliographie/">Über die NWBib</a></li>
+                          <li><a href="https://www.landesbibliothek-nrw.de/aufgaben-der-landesbibliotheken/nordrhein-westfaelische-bibliographie">Über die NWBib</a></li>
                           <li><a href="@nwbib.routes.Application.journals()">Ausgewertete Zeitschriften</a></li>
                           <li><a href="mailto:lobid-admin@@hbz-nrw.de?subject=Feedback%20zur%20NWBib,%20aktuelle%20URL%20@controllers.nwbib.Application.currentUri()">Feedback</a></li>
                           <li class="divider"></li>


### PR DESCRIPTION
I think there was no PR for this change yet, and it's not deployed to production.

Deployed to test: https://test.nwbib.de/