### PR TITLE
Handle invalid URIs, return full value instead of host (#630)

### DIFF
--- a/app/views/TableRow.java
+++ b/app/views/TableRow.java
@@ -219,8 +219,16 @@ public enum TableRow {
 		}
 		String label =
 				labels.isPresent() && labels.get().size() > 0 ? labels.get().get(0)
-						: value.startsWith("http") ? URI.create(value).getHost() : value;
+						: value.startsWith("http") ? hostFromUri(value) : value;
 		return new String[] { value, label };
+	}
+
+	private static String hostFromUri(String value) {
+		try {
+			return URI.create(value).getHost();
+		} catch (IllegalArgumentException e) {
+			return value;
+		}
 	}
 
 	public abstract String process(JsonNode doc, String property, String param,


### PR DESCRIPTION
Will resolve #630.

Deployed to test, see https://test.nwbib.de/990226301940206441